### PR TITLE
Undo reverting hardware config table PRs in validated model cards PR

### DIFF
--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTable.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTable.tsx
@@ -1,96 +1,52 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 import * as React from 'react';
-import { Table, Thead, Tbody, Tr, Th } from '@patternfly/react-table';
+import { DashboardEmptyTableView, Table } from 'mod-arch-shared';
 import { Spinner } from '@patternfly/react-core';
+import { OuterScrollContainer } from '@patternfly/react-table';
 import { CatalogPerformanceMetricsArtifact } from '~/app/modelCatalogTypes';
 import { hardwareConfigColumns } from './HardwareConfigurationTableColumns';
 import HardwareConfigurationTableRow from './HardwareConfigurationTableRow';
 
 type HardwareConfigurationTableProps = {
-  configurations: CatalogPerformanceMetricsArtifact[];
+  performanceArtifacts: CatalogPerformanceMetricsArtifact[];
   isLoading?: boolean;
 };
 
-const HardwareConfigurationTable = ({
-  configurations,
+const HardwareConfigurationTable: React.FC<HardwareConfigurationTableProps> = ({
+  performanceArtifacts,
   isLoading = false,
-}: HardwareConfigurationTableProps): React.JSX.Element => {
-  const [sortBy, setSortBy] = React.useState<{ index: number; direction: 'asc' | 'desc' }>({
-    index: 0,
-    direction: 'asc',
-  });
-  const [sortedConfigurations, setSortedConfigurations] = React.useState(configurations);
-
-  React.useEffect(() => {
-    const column = hardwareConfigColumns[sortBy.index];
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (column && column.sortable && typeof column.sortable === 'function') {
-      const sorted = [...configurations].toSorted((a, b) => {
-        const result = (
-          column.sortable as (
-            a: CatalogPerformanceMetricsArtifact,
-            b: CatalogPerformanceMetricsArtifact,
-            keyField: string,
-          ) => number
-        )(a, b, column.field);
-        return sortBy.direction === 'asc' ? result : -result;
-      });
-      setSortedConfigurations(sorted);
-    } else {
-      setSortedConfigurations(configurations);
-    }
-  }, [configurations, sortBy]);
-
-  const onSort = React.useCallback(
-    (_event: React.MouseEvent, index: number, direction: 'asc' | 'desc') => {
-      setSortBy({ index, direction });
-    },
-    [],
-  );
-
+}) => {
   if (isLoading) {
     return <Spinner size="lg" />;
   }
 
-  return (
-    <Table data-testid="hardware-configuration-table" variant="compact" isStickyHeader>
-      <Thead>
-        <Tr>
-          {hardwareConfigColumns.map((column, index) => {
-            const renderLabel = () => {
-              if (column.label.includes('\n')) {
-                const parts = column.label.split('\n');
-                return (
-                  <>
-                    {parts[0]}
-                    <br />
-                    {parts[1]}
-                  </>
-                );
-              }
-              return column.label;
-            };
+  // TODO when we add filters - lift these out as props, reference what tables like RegisteredModelTable do
+  const toolbarContent = <>TODO filter toolbar goes here</>;
+  const clearFilters = () => {
+    // TODO
+  };
 
-            return (
-              <Th
-                key={column.field}
-                isStickyColumn={index < 2}
-                stickyMinWidth={index < 2 ? `${column.width}ch` : undefined}
-                modifier="fitContent"
-                sort={column.sortable ? { onSort, columnIndex: index, sortBy } : undefined}
-              >
-                {renderLabel()}
-              </Th>
-            );
-          })}
-        </Tr>
-      </Thead>
-      <Tbody>
-        {sortedConfigurations.map((config, index) => (
-          <HardwareConfigurationTableRow key={index} configuration={config} />
-        ))}
-      </Tbody>
-    </Table>
+  return (
+    <OuterScrollContainer>
+      <Table
+        data-testid="hardware-configuration-table"
+        variant="compact"
+        isStickyHeader
+        hasStickyColumns
+        data={performanceArtifacts}
+        columns={hardwareConfigColumns}
+        toolbarContent={toolbarContent}
+        onClearFilters={clearFilters}
+        defaultSortColumn={0}
+        emptyTableView={<DashboardEmptyTableView onClearFilters={clearFilters} />}
+        rowRenderer={(artifact) => (
+          <HardwareConfigurationTableRow
+            key={`${artifact.customProperties.hardware?.string_value} ${artifact.customProperties.hardware_count?.int_value}`}
+            performanceArtifact={artifact}
+          />
+        )}
+      />
+    </OuterScrollContainer>
   );
 };
 

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableColumns.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableColumns.ts
@@ -1,5 +1,8 @@
 import { SortableData } from 'mod-arch-shared';
-import { CatalogPerformanceMetricsArtifact } from '~/app/modelCatalogTypes';
+import {
+  CatalogPerformanceMetricsArtifact,
+  PerformanceMetricsCustomProperties,
+} from '~/app/modelCatalogTypes';
 import {
   getDoubleValue,
   getHardwareConfiguration,
@@ -8,30 +11,47 @@ import {
   getTotalRps,
 } from '~/app/pages/modelCatalog/utils/performanceMetricsUtils';
 
-export const hardwareConfigColumns: SortableData<CatalogPerformanceMetricsArtifact>[] = [
+export type HardwareConfigColumnField = keyof PerformanceMetricsCustomProperties | 'total_rps';
+
+export type HardwareConfigColumn = Omit<
+  SortableData<CatalogPerformanceMetricsArtifact>,
+  'field'
+> & { field: HardwareConfigColumnField };
+
+// Note: The labels of most columns here include a non-breaking space (U+00a0) to selectively control word wrap.
+// Your editor may highlight these and warn you that "The character U+00a0 is invisible."
+// This character is ideally represented by the HTML entity &nbsp; but these strings can't contain HTML entities.
+export const hardwareConfigColumns: HardwareConfigColumn[] = [
   {
     field: 'hardware',
-    label: 'Hardware\nConfiguration',
+    label: 'Hardware Configuration',
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
     ): number => getHardwareConfiguration(a).localeCompare(getHardwareConfiguration(b)),
-    width: 25,
+    isStickyColumn: true,
+    stickyMinWidth: '162px',
+    stickyLeftOffset: '0',
+    modifier: 'wrap',
   },
   {
     field: 'hardware_count',
-    label: 'Total\nHardware',
+    label: 'Total Hardware',
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
     ): number =>
       getIntValue(a.customProperties, 'hardware_count') -
       getIntValue(b.customProperties, 'hardware_count'),
-    width: 20,
+    isStickyColumn: true,
+    hasRightBorder: true,
+    stickyMinWidth: '130px',
+    stickyLeftOffset: '162px',
+    modifier: 'wrap',
   },
   {
     field: 'requests_per_second',
-    label: 'RPS per\nReplica',
+    label: 'RPS per Replica',
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
@@ -39,19 +59,21 @@ export const hardwareConfigColumns: SortableData<CatalogPerformanceMetricsArtifa
       getDoubleValue(a.customProperties, 'requests_per_second') -
       getDoubleValue(b.customProperties, 'requests_per_second'),
     width: 20,
+    modifier: 'wrap',
   },
   {
     field: 'total_rps',
-    label: 'Total\nRPS',
+    label: 'Total RPS',
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
     ): number => getTotalRps(a.customProperties) - getTotalRps(b.customProperties),
     width: 20,
+    modifier: 'wrap',
   },
   {
     field: 'ttft_mean',
-    label: 'TTFT Latency\nMean',
+    label: 'TTFT Latency Mean',
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
@@ -59,10 +81,11 @@ export const hardwareConfigColumns: SortableData<CatalogPerformanceMetricsArtifa
       getDoubleValue(a.customProperties, 'ttft_mean') -
       getDoubleValue(b.customProperties, 'ttft_mean'),
     width: 20,
+    modifier: 'wrap',
   },
   {
     field: 'ttft_p90',
-    label: 'TTFT Latency\nP90',
+    label: 'TTFT Latency P90',
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
@@ -70,10 +93,11 @@ export const hardwareConfigColumns: SortableData<CatalogPerformanceMetricsArtifa
       getDoubleValue(a.customProperties, 'ttft_p90') -
       getDoubleValue(b.customProperties, 'ttft_p90'),
     width: 20,
+    modifier: 'wrap',
   },
   {
     field: 'ttft_p95',
-    label: 'TTFT Latency\nP95',
+    label: 'TTFT Latency P95',
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
@@ -81,10 +105,11 @@ export const hardwareConfigColumns: SortableData<CatalogPerformanceMetricsArtifa
       getDoubleValue(a.customProperties, 'ttft_p95') -
       getDoubleValue(b.customProperties, 'ttft_p95'),
     width: 20,
+    modifier: 'wrap',
   },
   {
     field: 'ttft_p99',
-    label: 'TTFT Latency\nP99',
+    label: 'TTFT Latency P99',
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
@@ -92,10 +117,11 @@ export const hardwareConfigColumns: SortableData<CatalogPerformanceMetricsArtifa
       getDoubleValue(a.customProperties, 'ttft_p99') -
       getDoubleValue(b.customProperties, 'ttft_p99'),
     width: 20,
+    modifier: 'wrap',
   },
   {
     field: 'e2e_mean',
-    label: 'E2E Latency\nMean',
+    label: 'E2E Latency Mean',
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
@@ -103,40 +129,44 @@ export const hardwareConfigColumns: SortableData<CatalogPerformanceMetricsArtifa
       getDoubleValue(a.customProperties, 'e2e_mean') -
       getDoubleValue(b.customProperties, 'e2e_mean'),
     width: 20,
+    modifier: 'wrap',
   },
   {
     field: 'e2e_p90',
-    label: 'E2E Latency\nP90',
+    label: 'E2E Latency P90',
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
     ): number =>
       getDoubleValue(a.customProperties, 'e2e_p90') - getDoubleValue(b.customProperties, 'e2e_p90'),
     width: 20,
+    modifier: 'wrap',
   },
   {
     field: 'e2e_p95',
-    label: 'E2E Latency\nP95',
+    label: 'E2E Latency P95',
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
     ): number =>
       getDoubleValue(a.customProperties, 'e2e_p95') - getDoubleValue(b.customProperties, 'e2e_p95'),
     width: 20,
+    modifier: 'wrap',
   },
   {
     field: 'e2e_p99',
-    label: 'E2E Latency\nP99',
+    label: 'E2E Latency P99',
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
     ): number =>
       getDoubleValue(a.customProperties, 'e2e_p99') - getDoubleValue(b.customProperties, 'e2e_p99'),
     width: 20,
+    modifier: 'wrap',
   },
   {
     field: 'tps_mean',
-    label: 'TPS Latency\nMean',
+    label: 'TPS Latency Mean',
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
@@ -144,40 +174,44 @@ export const hardwareConfigColumns: SortableData<CatalogPerformanceMetricsArtifa
       getDoubleValue(a.customProperties, 'tps_mean') -
       getDoubleValue(b.customProperties, 'tps_mean'),
     width: 20,
+    modifier: 'wrap',
   },
   {
     field: 'tps_p90',
-    label: 'TPS Latency\nP90',
+    label: 'TPS Latency P90',
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
     ): number =>
       getDoubleValue(a.customProperties, 'tps_p90') - getDoubleValue(b.customProperties, 'tps_p90'),
     width: 20,
+    modifier: 'wrap',
   },
   {
     field: 'tps_p95',
-    label: 'TPS Latency\nP95',
+    label: 'TPS Latency P95',
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
     ): number =>
       getDoubleValue(a.customProperties, 'tps_p95') - getDoubleValue(b.customProperties, 'tps_p95'),
     width: 20,
+    modifier: 'wrap',
   },
   {
     field: 'tps_p99',
-    label: 'TPS Latency\nP99',
+    label: 'TPS Latency P99',
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
     ): number =>
       getDoubleValue(a.customProperties, 'tps_p99') - getDoubleValue(b.customProperties, 'tps_p99'),
     width: 20,
+    modifier: 'wrap',
   },
   {
     field: 'itl_mean',
-    label: 'ITL Latency\nMean',
+    label: 'ITL Latency Mean',
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
@@ -185,40 +219,44 @@ export const hardwareConfigColumns: SortableData<CatalogPerformanceMetricsArtifa
       getDoubleValue(a.customProperties, 'itl_mean') -
       getDoubleValue(b.customProperties, 'itl_mean'),
     width: 20,
+    modifier: 'wrap',
   },
   {
     field: 'itl_p90',
-    label: 'ITL Latency\nP90',
+    label: 'ITL Latency P90',
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
     ): number =>
       getDoubleValue(a.customProperties, 'itl_p90') - getDoubleValue(b.customProperties, 'itl_p90'),
     width: 20,
+    modifier: 'wrap',
   },
   {
     field: 'itl_p95',
-    label: 'ITL Latency\nP95',
+    label: 'ITL Latency P95',
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
     ): number =>
       getDoubleValue(a.customProperties, 'itl_p95') - getDoubleValue(b.customProperties, 'itl_p95'),
     width: 20,
+    modifier: 'wrap',
   },
   {
     field: 'itl_p99',
-    label: 'ITL Latency\nP99',
+    label: 'ITL Latency P99',
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
     ): number =>
       getDoubleValue(a.customProperties, 'itl_p99') - getDoubleValue(b.customProperties, 'itl_p99'),
     width: 20,
+    modifier: 'wrap',
   },
   {
     field: 'max_input_tokens',
-    label: 'Max Input\nTokens',
+    label: 'Max Input Tokens',
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
@@ -226,10 +264,11 @@ export const hardwareConfigColumns: SortableData<CatalogPerformanceMetricsArtifa
       getDoubleValue(a.customProperties, 'max_input_tokens') -
       getDoubleValue(b.customProperties, 'max_input_tokens'),
     width: 20,
+    modifier: 'wrap',
   },
   {
     field: 'max_output_tokens',
-    label: 'Max Output\nTokens',
+    label: 'Max Output Tokens',
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
@@ -237,10 +276,11 @@ export const hardwareConfigColumns: SortableData<CatalogPerformanceMetricsArtifa
       getDoubleValue(a.customProperties, 'max_output_tokens') -
       getDoubleValue(b.customProperties, 'max_output_tokens'),
     width: 20,
+    modifier: 'wrap',
   },
   {
     field: 'mean_input_tokens',
-    label: 'Mean Input\nTokens',
+    label: 'Mean Input Tokens',
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
@@ -248,10 +288,11 @@ export const hardwareConfigColumns: SortableData<CatalogPerformanceMetricsArtifa
       getDoubleValue(a.customProperties, 'mean_input_tokens') -
       getDoubleValue(b.customProperties, 'mean_input_tokens'),
     width: 20,
+    modifier: 'wrap',
   },
   {
     field: 'mean_output_tokens',
-    label: 'Mean Output\nTokens',
+    label: 'Mean Output Tokens',
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
@@ -259,10 +300,11 @@ export const hardwareConfigColumns: SortableData<CatalogPerformanceMetricsArtifa
       getDoubleValue(a.customProperties, 'mean_output_tokens') -
       getDoubleValue(b.customProperties, 'mean_output_tokens'),
     width: 20,
+    modifier: 'wrap',
   },
   {
     field: 'framework_version',
-    label: 'vLLM\nVersion',
+    label: 'vLLM Version',
     sortable: (
       a: CatalogPerformanceMetricsArtifact,
       b: CatalogPerformanceMetricsArtifact,
@@ -272,5 +314,6 @@ export const hardwareConfigColumns: SortableData<CatalogPerformanceMetricsArtifa
       return versionA.localeCompare(versionB);
     },
     width: 20,
+    modifier: 'wrap',
   },
 ];

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableColumns.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableColumns.ts
@@ -4,12 +4,10 @@ import {
   PerformanceMetricsCustomProperties,
 } from '~/app/modelCatalogTypes';
 import {
-  getDoubleValue,
   getHardwareConfiguration,
-  getIntValue,
-  getStringValue,
   getTotalRps,
 } from '~/app/pages/modelCatalog/utils/performanceMetricsUtils';
+import { getDoubleValue, getIntValue, getStringValue } from '~/app/utils';
 
 export type HardwareConfigColumnField = keyof PerformanceMetricsCustomProperties | 'total_rps';
 

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableRow.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableRow.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Td, Tr } from '@patternfly/react-table';
+import { Th, Td, Tr } from '@patternfly/react-table';
 import { CatalogPerformanceMetricsArtifact } from '~/app/modelCatalogTypes';
 import {
   formatLatency,
@@ -10,21 +10,24 @@ import {
   getStringValue,
   getTotalRps,
 } from '~/app/pages/modelCatalog/utils/performanceMetricsUtils';
-import { hardwareConfigColumns } from './HardwareConfigurationTableColumns';
+import {
+  HardwareConfigColumnField,
+  hardwareConfigColumns,
+} from './HardwareConfigurationTableColumns';
 
 type HardwareConfigurationTableRowProps = {
-  configuration: CatalogPerformanceMetricsArtifact;
+  performanceArtifact: CatalogPerformanceMetricsArtifact;
 };
 
-const HardwareConfigurationTableRow = ({
-  configuration,
-}: HardwareConfigurationTableRowProps): React.JSX.Element => {
-  const getCellValue = (field: string): string | number => {
-    const { customProperties } = configuration;
+const HardwareConfigurationTableRow: React.FC<HardwareConfigurationTableRowProps> = ({
+  performanceArtifact,
+}) => {
+  const getCellValue = (field: HardwareConfigColumnField): string | number => {
+    const { customProperties } = performanceArtifact;
 
     switch (field) {
       case 'hardware':
-        return getHardwareConfiguration(configuration);
+        return getHardwareConfiguration(performanceArtifact);
       case 'hardware_count':
         return getIntValue(customProperties, 'hardware_count');
       case 'requests_per_second':
@@ -60,14 +63,18 @@ const HardwareConfigurationTableRow = ({
     }
   };
 
+  // TODO sticky isn't quite working with both columns and the scroll container is weird. double check PF docs
+
   return (
     <Tr>
-      {hardwareConfigColumns.map((column, index) => (
+      {hardwareConfigColumns.map((column) => (
         <Td
           key={column.field}
           dataLabel={column.label.replace('\n', ' ')}
-          isStickyColumn={index < 2}
-          stickyMinWidth={index < 2 ? `${column.width}ch` : undefined}
+          isStickyColumn={column.isStickyColumn}
+          stickyMinWidth={column.stickyMinWidth}
+          stickyLeftOffset={column.stickyLeftOffset}
+          hasRightBorder={column.hasRightBorder}
           modifier="fitContent"
         >
           {getCellValue(column.field)}

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableRow.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableRow.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Th, Td, Tr } from '@patternfly/react-table';
+import { Td, Tr } from '@patternfly/react-table';
 import { CatalogPerformanceMetricsArtifact } from '~/app/modelCatalogTypes';
 import {
   formatLatency,

--- a/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableRow.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableRow.tsx
@@ -4,12 +4,10 @@ import { CatalogPerformanceMetricsArtifact } from '~/app/modelCatalogTypes';
 import {
   formatLatency,
   formatTokenValue,
-  getDoubleValue,
   getHardwareConfiguration,
-  getIntValue,
-  getStringValue,
   getTotalRps,
 } from '~/app/pages/modelCatalog/utils/performanceMetricsUtils';
+import { getDoubleValue, getIntValue, getStringValue } from '~/app/utils';
 import {
   HardwareConfigColumnField,
   hardwareConfigColumns,

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/PerformanceInsightsView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/PerformanceInsightsView.tsx
@@ -28,7 +28,10 @@ const PerformanceInsightsView = (): React.JSX.Element => {
               </Flex>
             </FlexItem>
             <FlexItem>
-              <HardwareConfigurationTable configurations={configurations} isLoading={isLoading} />
+              <HardwareConfigurationTable
+                performanceArtifacts={configurations}
+                isLoading={isLoading}
+              />
             </FlexItem>
           </Flex>
         </CardBody>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/performanceMetricsUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/performanceMetricsUtils.ts
@@ -2,49 +2,7 @@ import {
   CatalogPerformanceMetricsArtifact,
   PerformanceMetricsCustomProperties,
 } from '~/app/modelCatalogTypes';
-import {
-  ModelRegistryCustomPropertyString,
-  ModelRegistryCustomPropertyInt,
-  ModelRegistryCustomPropertyDouble,
-  ModelRegistryMetadataType,
-} from '~/app/types';
-
-export const getStringValue = (
-  customProperties: PerformanceMetricsCustomProperties | undefined,
-  key: keyof PerformanceMetricsCustomProperties,
-): string => {
-  const prop = customProperties?.[key];
-  if (prop && prop.metadataType === ModelRegistryMetadataType.STRING) {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    return (prop as ModelRegistryCustomPropertyString).string_value;
-  }
-  return '-';
-};
-
-export const getIntValue = (
-  customProperties: PerformanceMetricsCustomProperties | undefined,
-  key: keyof PerformanceMetricsCustomProperties,
-): number => {
-  const prop = customProperties?.[key];
-  if (prop && prop.metadataType === ModelRegistryMetadataType.INT) {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    const value = (prop as ModelRegistryCustomPropertyInt).int_value;
-    return value ? parseInt(value, 10) : 0;
-  }
-  return 0;
-};
-
-export const getDoubleValue = (
-  customProperties: PerformanceMetricsCustomProperties | undefined,
-  key: keyof PerformanceMetricsCustomProperties,
-): number => {
-  const prop = customProperties?.[key];
-  if (prop && prop.metadataType === ModelRegistryMetadataType.DOUBLE) {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    return (prop as ModelRegistryCustomPropertyDouble).double_value;
-  }
-  return 0;
-};
+import { getDoubleValue, getIntValue, getStringValue } from '~/app/utils';
 
 export const getHardwareConfiguration = (artifact: CatalogPerformanceMetricsArtifact): string => {
   const count = getIntValue(artifact.customProperties, 'hardware_count');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Updates https://github.com/kubeflow/model-registry/pull/1701 to cherry-pick the same commits from https://github.com/YuliaKrimerman/model-registry/pull/2 that were originally merged into https://github.com/kubeflow/model-registry/pull/1664 (which was merged to main).

The changes for 1701 were based on the version of 1664 from before #2, and in moving those unmerged changes to a new branch based on main, the already merged changes from #2 were reverted. Merging this PR will cherrypick them back onto 1701 which should "revert the revert" and these lines will no longer show up on the diff for that PR.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](../OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
